### PR TITLE
Updates to combine nil and pay agent journeys

### DIFF
--- a/app/views/v6/_routes.js
+++ b/app/views/v6/_routes.js
@@ -6,13 +6,13 @@ var version = "v6";
 
 router.get('/v6/tasks', function(req, res) {
     req.session.data['scenario'] = 'T21';
-    if(req.session.data['TaskAmount']){
+    if(req.session.data['TaskAmount'] > '2'){
         req.session.data['TaskAmount'] = req.session.data['TaskAmount'] - 1;
         req.session.data['TaskAmountReady'] = req.session.data['TaskAmount'] - 1;
 
     }
     else{
-        req.session.data['TaskAmount'] = Math.floor(Math.random() * 15) + 1;
+        req.session.data['TaskAmount'] = Math.floor(Math.random() * 15) + 2;
         req.session.data['TaskAmountReady'] = req.session.data['TaskAmount'] - 1;
     }
 

--- a/app/views/v6/tasks/_taskroutes.js
+++ b/app/views/v6/tasks/_taskroutes.js
@@ -5,7 +5,7 @@ var version = "v6";
 
 router.get('/'+version+'/tasks/randomise', function(req, res) {
     //this randomises whether we display nil or pay award first
-    
+    // whichever displays first, the opposite will display second and then they keep alternating
     if(req.session.data['taskType']){
         if(req.session.data['taskType']=='pay'){
             req.session.data['taskType'] = 'nil'
@@ -24,6 +24,51 @@ router.get('/'+version+'/tasks/randomise', function(req, res) {
         }
         
     }
+
+    // array to switch month from an integer to a real name
+    var monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+
+    // this creates the backdating period date
+    // today minus 88 days (backdating is 3 months)
+    var date = new Date(); //get todays date
+    var last = new Date(date.getTime() - (90 * 24 * 60 * 60 * 1000)); //backdating period start date
+
+    // this creates the pansion payment dates
+    var pension1 = new Date(date.getTime() - (29 * 24 * 60 * 60 * 1000)); //pension dates
+    var pension2 = new Date(pension1.getTime() - (30 * 24 * 60 * 60 * 1000));
+    var pension3 = new Date(pension2.getTime() - (31 * 24 * 60 * 60 * 1000));
+    var pension4 = new Date(pension3.getTime() - (30 * 24 * 60 * 60 * 1000));
+    var pension5 = new Date(pension4.getTime() - (30 * 24 * 60 * 60 * 1000));
+    var pension6 = new Date(pension5.getTime() - (29 * 24 * 60 * 60 * 1000));
+
+    // this writes all the calculated dates, in a usable format, to sesssions to use on the prototype screens
+    req.session.data['backdatingDate'] = last.getDate() + ' ' + monthNames[last.getMonth()] + ' ' + last.getFullYear();
+    req.session.data['claimSubmittedDate'] = last.getDate() + ' ' + monthNames[date.getMonth()]+ ' ' + date.getFullYear();
+    req.session.data['pension1'] = pension1.getDate() + ' ' + monthNames[pension1.getMonth()] + ' ' + pension1.getFullYear();
+    req.session.data['pension2'] = pension2.getDate() + ' ' + monthNames[pension2.getMonth()] + ' ' + pension2.getFullYear();
+    req.session.data['pension3'] = pension3.getDate() + ' ' + monthNames[pension3.getMonth()] + ' ' + pension3.getFullYear();
+    req.session.data['pension4'] = pension4.getDate() + ' ' + monthNames[pension4.getMonth()] + ' ' + pension4.getFullYear();
+    req.session.data['pension5'] = pension5.getDate() + ' ' + monthNames[pension5.getMonth()] + ' ' + pension5.getFullYear();
+    req.session.data['pension6'] = pension6.getDate() + ' ' + monthNames[pension6.getMonth()] + ' ' + pension6.getFullYear();
+
+    // this resets the success banner on the task selection screen
+    req.session.data['TaskSuccess'] = 'no';
+
+    //this creates the data for pension3
+    req.session.data['scenario3-pension1-net'] = "350";
+    req.session.data['scenario3-pension1-selected'] = "Yes";
+    req.session.data['scenario3-pension2-net'] = "320";
+    req.session.data['scenario3-pension2-selected'] = "Yes";
+    req.session.data['scenario3-pension3-net'] = "300";
+    req.session.data['scenario3-pension3-selected'] = "No";
+    req.session.data['scenario3-pension4-net'] = "300";
+    req.session.data['scenario3-pension4-selected'] = "No";
+    req.session.data['scenario3-pension5-net']= "300";
+    req.session.data['scenario3-pension5-selected'] = "No";
+    req.session.data['scenario3-pension6-net'] = "300";
+    req.session.data['scenario3-pension6-selected'] = "No";
+    req.session.data['scenario3-pension-average'] = "335";
+
     res.redirect("/"+version+"/tasks/tasklist")
 });
 
@@ -70,7 +115,13 @@ router.post('/' + version + '/tasks/personal-details', function(req, res) {
 router.post('/' + version + '/tasks/benefits', function(req, res) {
     if(req.session.data['BenefitInterests'] == 'no' && req.session.data['ReceivingBenefits'] == 'no') {
         req.session.data['Benefits'] = 'no'
-        res.redirect("non-dependents")
+        if(req.session.data['taskType']=='nil'){
+            res.redirect("tasklist")
+        }
+        else{
+            res.redirect("non-dependents")
+        }
+        
     } 
     else{
         res.redirect("dropout")
@@ -86,6 +137,117 @@ router.post('/' + version + '/tasks/non-dependents', function(req, res) {
     }
 });
 
+router.post('/' + version + '/tasks/pension1', function(req, res) {
+    if(req.session.data['pension1Complete'] == 'yes') {
+        if(req.session.data['pension3Complete'] == 'yes' && req.session.data['pension2Complete']){
+            res.redirect("tasklist")
+        }
+        else if(req.session.data['pension2Complete']){
+            res.redirect("pension3")
+        }
+        else{
+            res.redirect("pension2")
+        }
+    } 
+    else{
+        res.redirect("dropout")
+    }
+});
+
+router.post('/' + version + '/tasks/pension2', function(req, res) {
+    if(req.session.data['pension1Complete'] == 'yes' && req.session.data['pension3Complete'] == 'yes'){
+        res.redirect("tasklist")
+    }
+    else if(req.session.data['pension1Complete'] == 'yes'){
+        res.redirect("pension3")
+    }
+    else{
+        res.redirect("pension1")
+    }
+});
+
+router.post('/' + version + '/tasks/pension3', function(req, res) {
+    if(req.session.data['pension3Complete'] == 'yes') {
+        if(req.session.data['pension1Complete'] == 'yes' && req.session.data['pension2Complete']){
+            res.redirect("tasklist")
+        }
+        else if(req.session.data['pension2Complete']){
+            res.redirect("pension1")
+        }
+        else{
+            res.redirect("pension2")
+        }
+    } 
+    else{
+        res.redirect("pension3-choose-amounts")
+    }
+});
+
+router.post('/' + version + '/tasks/pension3-choose-amounts', (req, res) => {
+    var count = 0;
+    var average = 0;
+  
+    if(req.session.data['scenario3-pension1-selected'] == 'Yes'){
+      average +=  parseFloat(req.session.data['scenario3-pension1-net']);
+      count++
+    }
+    else{
+      req.session.data['scenario3-pension1-selected'] = 'No'
+    }
+  
+    if(req.session.data['scenario3-pension2-selected'] == 'Yes'){
+      average +=  parseFloat(req.session.data['scenario3-pension2-net']);
+      count++
+    }
+    else{
+      req.session.data['scenario3-pension2-selected'] = 'No'
+    }
+  
+    if(req.session.data['scenario3-pension3-selected'] == 'Yes'){
+      average +=  parseFloat(req.session.data['scenario3-pension3-net']);
+      count++
+    }
+    else{
+      req.session.data['scenario3-pension3-selected'] = 'No'
+    }
+  
+    if(req.session.data['scenario3-pension4-selected'] == 'Yes'){
+      average +=  parseFloat(req.session.data['scenario3-pension4-net']);
+      count++
+    }
+    else{
+      req.session.data['scenario3-pension4-selected'] = 'No'
+    } 
+  
+    if(req.session.data['scenario3-pension5-selected'] == 'Yes'){
+      average +=  parseFloat(req.session.data['scenario3-pension5-net']);
+      count++
+    }
+    else{
+      req.session.data['scenario3-pension5-selected'] = 'No'
+    }
+  
+    if(req.session.data['scenario3-pension6-selected'] == 'Yes'){
+      average += parseFloat(req.session.data['scenario3-pension6-net']);
+      count++
+    }
+    else{
+      req.session.data['scenario3-pension6-selected'] = 'No'
+    }
+  
+  if(count > 1){
+    req.session.data['scenario3-selection-error']= 'false'
+    req.session.data['pension3Complete']= ''
+    req.session.data['scenario3-pension-average'] = Math.round(average / count);
+    res.redirect(`pension3`);
+  }
+  else{
+    req.session.data['scenario3-selection-error']= 'true'
+    res.redirect(`pension3-choose-amounts`);
+  }
+  
+  })
+
 
 router.post('/' + version + '/tasks/dropout', function(req, res) {
     // Reset all sessions
@@ -93,8 +255,18 @@ router.post('/' + version + '/tasks/dropout', function(req, res) {
     req.session.data['OtherApplications'] = '';
     req.session.data['PersonalDetails'] = '';
     req.session.data['Benefits'] = '';
+    req.session.data['BenefitInterests'] = '';
+    req.session.data['ReceivingBenefits'] = '';
     req.session.data['NonDependents'] = '';
-    res.redirect("../tasks")
+    req.session.data['online'] = '';
+    req.session.data['telephone'] = '';
+    req.session.data['paper'] = '';
+    req.session.data['IDOC'] = '';
+    req.session.data['pension1Complete'] = '';
+    req.session.data['pension2Complete'] = '';
+    req.session.data['pension3Complete'] = '';
+    req.session.data['TaskSuccess'] = 'yes';
+    res.redirect("../tasks");
 });
 
 router.post('/' + version + '/tasks/tasklist', function(req, res) {
@@ -103,8 +275,17 @@ router.post('/' + version + '/tasks/tasklist', function(req, res) {
     req.session.data['OtherApplications'] = '';
     req.session.data['PersonalDetails'] = '';
     req.session.data['Benefits'] = '';
+    req.session.data['BenefitInterests'] = '';
+    req.session.data['ReceivingBenefits'] = '';
     req.session.data['NonDependents'] = '';
+    req.session.data['online'] = '';
+    req.session.data['telephone'] = '';
+    req.session.data['paper'] = '';
+    req.session.data['IDOC'] = '';
+    req.session.data['pension1Complete'] = '';
+    req.session.data['pension2Complete'] = '';
+    req.session.data['pension3Complete'] = '';
     req.session.data['TaskSuccess'] = 'yes';
-    res.redirect("../tasks")
+    res.redirect("../tasks");
 });
 

--- a/app/views/v6/tasks/bank-name.njk
+++ b/app/views/v6/tasks/bank-name.njk
@@ -44,7 +44,8 @@
 
                 <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="BankDetails" name="BankDetails" type="radio" value="yes">
+                    <input class="govuk-radios__input" id="BankDetails" name="BankDetails" type="radio" value="yes"
+                    {%if data['BankDetails']=="yes"%}checked="checked"{%endif%}>
                     <label class="govuk-label govuk-radios__label" for="BankDetails">
                     Yes
                     </label>

--- a/app/views/v6/tasks/benefits.njk
+++ b/app/views/v6/tasks/benefits.njk
@@ -48,19 +48,22 @@
             <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
                 <h3 class="govuk-fieldset__heading">
-                    Has the applicant received any qualifying benefits for premiums today or since [DATE]?
+                    Has the applicant received any qualifying benefits for premiums today or since {{data['backdatingDate']}}?
                 </h3>
                 </legend>
                 
                 <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="BankDetReceivingBenefitsails" name="ReceivingBenefits" type="radio" value="yes">
+                    <input class="govuk-radios__input" id="BankDetReceivingBenefitsails" name="ReceivingBenefits" type="radio" value="yes"
+                    {%if data['ReceivingBenefits']=="yes"%}checked="checked"{%endif%}
+                    >
                     <label class="govuk-label govuk-radios__label" for="ReceivingBenefits">
                     Yes
                     </label>
                 </div>
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="ReceivingBenefits-2" name="ReceivingBenefits" type="radio" value="no">
+                    <input class="govuk-radios__input" id="ReceivingBenefits-2" name="ReceivingBenefits" type="radio" value="no"
+                    {%if data['ReceivingBenefits']=="no"%}checked="checked"{%endif%}>
                     <label class="govuk-label govuk-radios__label" for="ReceivingBenefits-2">
                     No
                     </label>
@@ -73,19 +76,23 @@
             <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
                 <h1 class="govuk-fieldset__heading">
-                    Are there any open or closed interests shown for qualifying benefits for premiums today or since [DATE]?
+                    Are there any open or closed interests shown for qualifying benefits for premiums today or since {{data['backdatingDate']}}?
                 </h1>
                 </legend>
                 
                 <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="BenefitInterests" name="BenefitInterests" type="radio" value="yes">
+                    <input class="govuk-radios__input" id="BenefitInterests" name="BenefitInterests" type="radio" value="yes"
+                    {%if data['BenefitInterests']=="yes"%}checked="checked"{%endif%}
+                    >
                     <label class="govuk-label govuk-radios__label" for="BenefitInterests">
                     Yes
                     </label>
                 </div>
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="BenefitInterests-2" name="BenefitInterests" type="radio" value="no">
+                    <input class="govuk-radios__input" id="BenefitInterests-2" name="BenefitInterests" type="radio" value="no"
+                    {%if data['BenefitInterests']=="no"%}checked="checked"{%endif%}
+                    >
                     <label class="govuk-label govuk-radios__label" for="BenefitInterests-2">
                     No
                     </label>

--- a/app/views/v6/tasks/other-applications.njk
+++ b/app/views/v6/tasks/other-applications.njk
@@ -53,7 +53,7 @@
               <div class="govuk-checkboxes__item">
                 <input class="govuk-checkboxes__input" id="IDOC" name="IDOC" type="checkbox" value="yes"{%if data['IDOC'] == 'yes'%}checked='checked'{% endif %}>
                 <label class="govuk-label govuk-checkboxes__label" for="IDOC">
-                  IDOCs between [DATE] and today
+                  IDOCs between {{data['backdatingDate']}} and today
                 </label>
               </div>
               <div class="govuk-checkboxes__item">

--- a/app/views/v6/tasks/pension1.njk
+++ b/app/views/v6/tasks/pension1.njk
@@ -12,38 +12,34 @@
         {% include '../partials/name/eric.njk' %}
         <p><a href="javascript:history.back()" class="govuk-back-link">Back</a></p>
 
-        <h2 class="govuk-heading-l">Personal details</h2>
+        <h2 class="govuk-heading-l">Check the pension payments from AVIVA</h2>
 
         <div class="govuk-body">
-            Check if the information given in the application matches what is in Searchlight.
+            Claim submitted on {{data['claimSubmittedDate']}}.
         </div>
 
-        <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Name
-            </dt>
-            <dd class="govuk-summary-list__value">
-              Eric James Munroe
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Address
-            </dt>
-            <dd class="govuk-summary-list__value">
-              9 Wilthy St, Preston, PR2 7RT
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Phone number
-            </dt>
-            <dd class="govuk-summary-list__value">
-              07665 678776
-            </dd>
-          </div>
-        </dl>
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">Payment date (monthly)</th>
+              <th scope="col" class="govuk-table__header">Net pay</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <td scope="row" class="govuk-table__cell">{{data['pension1']}}</td>
+              <td class="govuk-table__cell">£120</td>
+            </tr>
+            <tr class="govuk-table__row">
+              <td scope="row" class="govuk-table__cell">{{data['pension2']}}</td>
+              <td class="govuk-table__cell">£120</td>
+            </tr>
+            <tr class="govuk-table__row">
+              <td scope="row" class="govuk-table__cell">{{data['pension3']}}</td>
+              <td class="govuk-table__cell">£120</td>
+            </tr>
+          </tbody>
+        </table>
 
         <form method="post">
             <div class="govuk-form-group">
@@ -56,15 +52,17 @@
                 
                 <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="PersonalDetails" name="PersonalDetails" type="radio" value="yes"
-                    {%if data['PersonalDetails']=="yes"%}checked="checked"{%endif%}
+                    <input class="govuk-radios__input" id="PersonalDetails" name="pension1Complete" type="radio" value="yes"
+                    {% if data['pension1Complete'] == 'yes' %}checked="checked"{% endif %} 
                     >
                     <label class="govuk-label govuk-radios__label" for="PersonalDetails">
                     Yes
                     </label>
                 </div>
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="PersonalDetails-2" name="PersonalDetails" type="radio" value="no">
+                    <input class="govuk-radios__input" id="PersonalDetails-2" name="pension1Complete" type="radio" value="no"
+                    {% if data['pension1Complete'] == 'no' %}checked="checked"{% endif %}
+                    >
                     <label class="govuk-label govuk-radios__label" for="PersonalDetails-2">
                     No
                     </label>

--- a/app/views/v6/tasks/pension2.njk
+++ b/app/views/v6/tasks/pension2.njk
@@ -1,0 +1,87 @@
+{# Set which global nav link to highlight #}
+{% set globalNavSection = 'tasks' %}
+
+{% extends "../layout.njk" %}
+
+{% set pageName = "Process application" %}
+
+{% block content %}
+<div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+        {% include '../partials/name/eric.njk' %}
+        <p><a href="javascript:history.back()" class="govuk-back-link">Back</a></p>
+
+        <h2 class="govuk-heading-l">Which pension payment from SUN LIFE should be used in the award decision?</h2>
+
+        <div class="govuk-body">
+            The payment you select should represent the income on the day the claim was submitted ({{data['claimSubmittedDate']}}).
+        </div>
+
+        <form method="post">
+
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <div class="govuk-radios" data-module="govuk-radios">
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="pension1" name="pension2Complete" type="radio" value="{{data['pension1']}}"
+                {% if data['pension2Complete'] == data['pension1'] %}checked="checked"{%endif%}
+                >
+                <label class="govuk-label govuk-radios__label" for="pension1">
+                  {{data['pension1']}}, £350
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="pension2" name="pension2Complete" type="radio" value="{{data['pension2']}}"
+                  {% if data['pension2Complete'] == data['pension2'] %}checked="checked"{%endif%}
+                >
+                <label class="govuk-label govuk-radios__label" for="pension2">
+                  {{data['pension2']}}, £350
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="pension3" name="pension2Complete" type="radio" value="{{data['pension3']}}"
+                  {% if data['pension2Complete'] == data['pension3'] %}checked="checked"{%endif%}
+                >
+                <label class="govuk-label govuk-radios__label" for="pension3">
+                  {{data['pension3']}}, £320
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="pension4" name="pension2Complete" type="radio" value="{{data['pension4']}}"
+                  {% if data['pension2Complete'] == data['pension4'] %}checked="checked"{%endif%}
+                >
+                <label class="govuk-label govuk-radios__label" for="pension4">
+                  {{data['pension4']}}, £320
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="pension5" name="pension2Complete" type="radio" value="{{data['pension5']}}"
+                  {% if data['pension2Complete'] == data['pension5'] %}checked="checked"{%endif%}
+                >
+                <label class="govuk-label govuk-radios__label" for="pension5">
+                  {{data['pension5']}}, £320
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="pension6" name="pension2Complete" type="radio" value="{{data['pension6']}}"
+                  {% if data['pension2Complete'] == data['pension6'] %}checked="checked"{%endif%}
+                >
+                <label class="govuk-label govuk-radios__label" for="pension6">
+                  {{data['pension6']}}, £320
+                </label>
+              </div>
+              
+          </fieldset>
+        </div>
+            
+        <button type="submit" class="govuk-button" data-module="govuk-button">
+            Continue
+        </button>
+
+        </form>
+
+</div>
+</div>
+
+{% endblock %}

--- a/app/views/v6/tasks/pension3-choose-amounts.njk
+++ b/app/views/v6/tasks/pension3-choose-amounts.njk
@@ -1,0 +1,100 @@
+{# Set which global nav link to highlight #}
+{% set globalNavSection = 'tasks' %}
+
+{% extends "../layout.njk" %}
+
+{% set pageName = "Process application" %}
+
+{% block content %}
+<div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+        {% include '../partials/name/eric.njk' %}
+        
+        {% if data['scenario3-selection-error'] == 'true'%}
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
+          <div role="alert">
+            <h2 class="govuk-error-summary__title">
+              There is a problem
+            </h2>
+            <div class="govuk-error-summary__body">
+              <ul class="govuk-list govuk-error-summary__list">
+                <li>
+                  <a href="selection-error">You must select at least 2 payments</a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        {% endif %}
+
+        <form method="post" class="form">
+          <div class="govuk-form-group {% if data['scenario3-selection-error'] == 'true'%} govuk-form-group--error {%endif%}">
+            <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+                <h1 class="govuk-fieldset__heading">
+                  Which pension payments from SUNLIFE PLC should be averaged?
+                </h1>
+              </legend>
+              <div id="waste-hint" class="govuk-body-l">
+                The payments you select should represent the income on the day the claim was submitted (29 June 2023).
+              </div>
+              
+              {% if data['scenario3-selection-error'] == 'true'%}
+                <p id="selection-error" class="govuk-error-message">
+                  <span class="govuk-visually-hidden">Error:</span> You must select at least 2 payments
+                </p>
+              {% endif %}
+
+              <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="amount" name="scenario3-pension1-selected" type="checkbox" value="Yes" {% if data['scenario3-pension1-selected'] == "Yes" %}checked="checked"{% endif %}>
+                  <label class="govuk-label govuk-checkboxes__label" for="amount">
+                    1 June 2023, £{{data['scenario3-pension1-net']}}
+                  </label>
+                </div>
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="amount-2" name="scenario3-pension2-selected" type="checkbox" value="Yes" {% if data['scenario3-pension2-selected'] == "Yes" %}checked="checked"{% endif %}>
+                  <label class="govuk-label govuk-checkboxes__label" for="amount-2">
+                    1 May 2023, £{{data['scenario3-pension2-net']}}
+                  </label>
+                </div>
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="amount-3" name="scenario3-pension3-selected" type="checkbox" value="Yes" {% if data['scenario3-pension3-selected'] == "Yes" %}checked="checked"{% endif %}>
+                  <label class="govuk-label govuk-checkboxes__label" for="amount-3">
+                    1 April 2023, £{{data['scenario3-pension3-net']}}
+                  </label>
+                </div>
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="amount-4" name="scenario3-pension4-selected" type="checkbox" value="Yes" {% if data['scenario3-pension4-selected'] == "Yes" %}checked="checked"{% endif %}>
+                  <label class="govuk-label govuk-checkboxes__label" for="amount-4">
+                    1 March 2023, £{{data['scenario3-pension4-net']}}
+                  </label>
+                </div>
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="amount-5" name="scenario3-pension5-selected" type="checkbox" value="Yes" {% if data['scenario3-pension5-selected'] == "Yes" %}checked="checked"{% endif %}>
+                  <label class="govuk-label govuk-checkboxes__label" for="amount-5">
+                    1 February 2023, £{{data['scenario3-pension5-net']}}
+                  </label>
+                </div>
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="amount-6" name="scenario3-pension6-selected" type="checkbox" value="Yes" {% if data['scenario3-pension6-selected'] == "Yes" %}checked="checked"{% endif %}>
+                  <label class="govuk-label govuk-checkboxes__label" for="amount-6">
+                    1 January 2023, £{{data['scenario3-pension6-net']}}
+                  </label>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+
+            <button type="submit" class="govuk-button" data-module="govuk-button">
+                Continue
+            </button>
+
+        </form>
+        
+
+</div>
+</div>
+
+{% endblock %}

--- a/app/views/v6/tasks/pension3.njk
+++ b/app/views/v6/tasks/pension3.njk
@@ -1,0 +1,147 @@
+{# Set which global nav link to highlight #}
+{% set globalNavSection = 'tasks' %}
+
+{% extends "../layout.njk" %}
+
+{% set pageName = "Process application" %}
+
+{% block content %}
+<div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+        {% include '../partials/name/eric.njk' %}
+        <p><a href="javascript:history.back()" class="govuk-back-link">Back</a></p>
+
+        <h2 class="govuk-heading-l">PRUDENTIAL's pension payments</h2>
+
+        <form method="post">
+          <table class="govuk-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">Payment date (monthly)</th>
+              <th scope="col" class="govuk-table__header">Net pay</th>
+              <th scope="col" class="govuk-table__header">Selected for averaging</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header">1 June 2023</th>
+              <td class="govuk-table__cell">£{{data['scenario3-pension1-net']}}</td>
+              <td class="govuk-table__cell"><strong
+                {% if data['scenario3-pension1-selected'] == "Yes" %}
+                  class="govuk-tag govuk-tag--blue">
+                {% else %}
+                  class="govuk-tag govuk-tag--light-blue">
+                {% endif %}
+                {{data['scenario3-pension1-selected']}}
+              </strong></td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header">1 May 2023</th>
+              <td class="govuk-table__cell">£ {{data['scenario3-pension2-net']}}</td>
+              <td class="govuk-table__cell"><strong 
+                {% if data['scenario3-pension2-selected'] == "Yes" %}
+                  class="govuk-tag govuk-tag--blue">
+                {% else %}
+                  class="govuk-tag govuk-tag--light-blue">
+                {% endif %}
+
+                {{data['scenario3-pension2-selected']}}
+              </strong></td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header">1 April 2023</th>
+              <td class="govuk-table__cell">£{{data['scenario3-pension3-net']}}</td>
+              <td class="govuk-table__cell"><strong 
+                
+                {% if data['scenario3-pension3-selected'] == "Yes" %}
+                  class="govuk-tag govuk-tag--blue">
+                {% else %}
+                  class="govuk-tag govuk-tag--light-blue">
+                {% endif %}
+
+                {{data['scenario3-pension3-selected']}}
+              </strong></td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header">1 March 2023</th>
+              <td class="govuk-table__cell">£{{data['scenario3-pension4-net']}}</td>
+              <td class="govuk-table__cell"><strong 
+                {% if data['scenario3-pension4-selected'] == "Yes" %}
+                  class="govuk-tag govuk-tag--blue">
+                {% else %}
+                  class="govuk-tag govuk-tag--light-blue">
+                {% endif %}
+                {{data['scenario3-pension4-selected']}}
+              </strong></td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header">1 February 2023</th>
+              <td class="govuk-table__cell">£{{data['scenario3-pension5-net']}}</td>
+              <td class="govuk-table__cell"><strong 
+                {% if data['scenario3-pension5-selected'] == "Yes" %}
+                  class="govuk-tag govuk-tag--blue">
+                {% else %}
+                  class="govuk-tag govuk-tag--light-blue">
+                {% endif %}
+                {{data['scenario3-pension5-selected']}}
+              </strong></td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header">1 January 2023</th>
+              <td class="govuk-table__cell">£{{data['scenario3-pension6-net']}}</td>
+              <td class="govuk-table__cell"><strong 
+                {% if data['scenario3-pension6-selected'] == "Yes" %}
+                  class="govuk-tag govuk-tag--blue">
+                {% else %}
+                  class="govuk-tag govuk-tag--light-blue">
+                {% endif %}
+                {{ data['scenario3-pension6-selected'] }}
+              </strong></td>
+            </tr>
+            
+
+
+          </tbody>
+        </table>
+
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <h1 class="govuk-fieldset__heading">
+                Does an average of £{{data['scenario3-pension-average']}} a month represent the applicant's income on the day the claim was submitted ({{data['claimSubmittedDate']}})?
+              </h1>
+            </legend>
+            <div class="govuk-radios--inline" data-module="govuk-radios">
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="whereDoYouLive-2" name="pension3Complete" type="radio" value="yes"
+                  {%if data['pension3Complete']=="yes"%}checked="checked"{%endif%}
+                >
+                <label class="govuk-label govuk-radios__label" for="whereDoYouLive-2">
+                  Yes
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="whereDoYouLive-3" name="pension3Complete" type="radio" value="no"
+                  {%if data['pension3Complete']=="no"%}checked="checked"{%endif%}
+                >
+                <label class="govuk-label govuk-radios__label" for="whereDoYouLive-3">
+                  No
+                </label>
+              </div>
+              
+            </div>
+          </fieldset>
+        </div>
+
+            <button type="submit" class="govuk-button" data-module="govuk-button">
+                Continue
+            </button>
+
+        </form>
+        
+
+</div>
+</div>
+
+{% endblock %}

--- a/app/views/v6/tasks/tasklist.njk
+++ b/app/views/v6/tasks/tasklist.njk
@@ -25,10 +25,8 @@
 
         {% if data['BankDetails'] == 'yes'%}
         <div class="govuk-task-list__status" id="before-you-start-1-status">
-          <strong class="govuk-tag govuk-tag--green">
-      Done
-    </strong>
-            </div>
+          Done
+        </div>
         {% else %}
         <div class="govuk-task-list__status" id="prepare-application-2-status">
           <strong class="govuk-tag govuk-tag--blue">
@@ -48,7 +46,7 @@
         {% if data['OtherApplications'] == 'no'%}
         <div class="govuk-task-list__status" id="before-you-start-1-status">
           Done
-            </div>
+        </div>
         {% else %}
         <div class="govuk-task-list__status" id="prepare-application-2-status">
           <strong class="govuk-tag govuk-tag--blue">
@@ -121,12 +119,12 @@
         </div>
         {% if data['Income'] == 'no'%}
         <div class="govuk-task-list__status" id="before-you-start-1-status">
-              Completed
-            </div>
+          Done
+        </div>
         {% else %}
         <div class="govuk-task-list__status" id="prepare-application-2-status">
           <strong class="govuk-tag govuk-tag--blue">
-            Incomplete
+            To do
           </strong>
         </div>
         {% endif %}
@@ -142,47 +140,87 @@
     <ul class="govuk-task-list">
       <li class="govuk-task-list__item govuk-task-list__item--with-link">
         <div class="govuk-task-list__name-and-hint">
-          <a class="govuk-link govuk-task-list__link" href="#" aria-describedby="prepare-application-1-status">AVIVA</a>
+          <a class="govuk-link govuk-task-list__link" href="pension1" aria-describedby="prepare-application-1-status">AVIVA</a>
         </div>
+        {% if data['pension1Complete'] == 'yes'%}
+        <div class="govuk-task-list__status" id="before-you-start-1-status">
+          Done
+        </div>
+        {% else %}
         <div class="govuk-task-list__status" id="prepare-application-2-status">
           <strong class="govuk-tag govuk-tag--blue">
             To do
           </strong>
         </div>
+        {% endif %}
       </li>
       <li class="govuk-task-list__item govuk-task-list__item--with-link">
         <div class="govuk-task-list__name-and-hint">
-          <a class="govuk-link govuk-task-list__link" href="#" aria-describedby="prepare-application-2-status">SUN LIFE</a>
+          <a class="govuk-link govuk-task-list__link" href="pension2" aria-describedby="prepare-application-2-status">SUN LIFE</a>
         </div>
+        {% if data['pension2Complete']%}
+        <div class="govuk-task-list__status" id="before-you-start-1-status">
+          Done
+        </div>
+        {% else %}
         <div class="govuk-task-list__status" id="prepare-application-2-status">
           <strong class="govuk-tag govuk-tag--blue">
             To do
           </strong>
         </div>
+        {% endif %}
       </li>
       <li class="govuk-task-list__item govuk-task-list__item--with-link">
         <div class="govuk-task-list__name-and-hint">
-          <a class="govuk-link govuk-task-list__link" href="#" aria-describedby="prepare-application-3-status">PRUDENTIAL</a>
+          <a class="govuk-link govuk-task-list__link" href="pension3" aria-describedby="prepare-application-3-status">PRUDENTIAL</a>
         </div>
+       {% if data['pension3Complete'] == 'yes'%}
+        <div class="govuk-task-list__status" id="before-you-start-1-status">
+          Done
+        </div>
+        {% else %}
         <div class="govuk-task-list__status" id="prepare-application-2-status">
           <strong class="govuk-tag govuk-tag--blue">
             To do
           </strong>
         </div>
+        {% endif %}
       </li>
     </ul>
 
     {% endif %}
 
   <!-- Payment success -->
-
-
-  {% if data['NilAward'] != 'yes' and data['BankDetails'] == 'yes' and data['OtherApplications'] == 'no' and data['PersonalDetails'] == 'yes' and data['Benefits'] == 'no' and data['NonDependents'] == 'no'%}
+  {% if data['taskType'] == 'pay' and data['BankDetails'] == 'yes' and data['OtherApplications'] == 'no' and data['PersonalDetails'] == 'yes' and data['Benefits'] == 'no' and data['NonDependents'] == 'no'%}
   <form method="post">
     <h3 class="govuk-heading-l govuk-!-padding-top-5 govuk-!-margin-bottom-2">Claimant entitled to an award</h3>
     <p class="govuk-body govuk-!-font-size-19 govuk-!-margin-bottom-6">
       A letter will be automatically sent to the claimant. It will notify them that they are
      entitled to Pension Credit and give details of the award amount.
+    </p>
+
+    <button type="submit" class="govuk-button" data-module="govuk-button">
+        Confirm and notify
+    </button>
+
+  </form>
+  {% endif %}
+
+  <!-- Nil award -->
+  {% 
+  if data['taskType'] == 'nil' 
+  and data['BankDetails'] == 'yes' 
+  and data['OtherApplications'] == 'no' 
+  and data['PersonalDetails'] == 'yes' 
+  and data['Benefits'] == 'no' 
+  and data['pension1Complete'] == 'yes'
+  and data['pension2Complete']
+  and data['pension3Complete'] == 'yes'
+  %}
+  <form method="post">
+    <h3 class="govuk-heading-l govuk-!-padding-top-5 govuk-!-margin-bottom-2">Not currently entitled</h3>
+    <p class="govuk-body govuk-!-font-size-19 govuk-!-margin-bottom-6">
+      A letter will be automatically sent to the applicant. It will notify them that they are not currently entitled to Pension Credit.
     </p>
 
     <button type="submit" class="govuk-button" data-module="govuk-button">


### PR DESCRIPTION
This adds both the nil award and pay award journeys.

It includes:
- A randomiser method so we can provide more lifelike task allocation. The service will randomise the first task generated then continue to switch between journeys each time a new task is requested.
- True dates for submission, backdating and pension payments based on the current date so they don't need to be continuously changed based on the user research date.

For reference Mabel is nil award and Eric is pay